### PR TITLE
Update .npmignore and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,6 @@
-
 # OSX
 #
 .DS_Store
-
-# node.js
-#
-node_modules/
-npm-debug.log
-yarn-error.log
-package-lock.json
-  
 
 # Xcode
 #
@@ -30,20 +21,34 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      
 
 # Android/IntelliJ
 #
 build/
 .idea
-.vscode
 .gradle
 local.properties
 *.iml
+android/gradle/
+android/gradlew
+android/gradlew.bat
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
 
 # BUCK
 buck-out/
 \.buckd/
-# *.keystore
-dev/
-.vscode
+*.keystore
+!debug.keystore
+
+# Bundle artifact
+*.jsbundle
+
+# CocoaPods
+/ios/Pods/
+
+.vscode/

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,1 @@
-example
-local_example
-.vscode
-.gitignore
-.gitattributes
-dev
-*.keystore
-package-lock.json
+example/

--- a/android/.npmignore
+++ b/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties

--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,0 +1,6 @@
+*/project.xcworkspace/
+*/xcuserdata/
+.DS_Store
+.npmignore
+Pods/
+build/

--- a/ios/RNNetworkState.xcworkspace/contents.xcworkspacedata
+++ b/ios/RNNetworkState.xcworkspace/contents.xcworkspacedata
@@ -1,9 +1,0 @@
-// !$*UTF8*$!
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "group:RNNetworkState.xcodeproj">
-   </FileRef>
-</Workspace>
-  

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "react-native-network-state",
   "version": "1.1.5",
   "description": "Network Reachability instantly module for React Native",
+  "files": [
+    "android",
+    "ios",
+    "fixAndroid.js",
+    "index.d.ts",
+    "RNNetworkState.podspec"
+  ],
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Use the `files` array in `package.json` to explicitly _include_ files to be distributed.
This leads to a small size reduction of the archive (by excluding unnecessary files like `.eslintrc`, `.flowconfig` etc), as well as removes any possibility of accidentally including build output.

Also set type declarations to the already existing file `index.d.ts`:

```
"types": "index.d.ts"
```